### PR TITLE
Add logout and current user support to auth flow

### DIFF
--- a/app/src/main/java/com/evolforge/core/auth/AuthFacade.java
+++ b/app/src/main/java/com/evolforge/core/auth/AuthFacade.java
@@ -3,8 +3,10 @@ package com.evolforge.core.auth;
 import com.evolforge.core.auth.domain.UserAccount;
 import com.evolforge.core.auth.service.AuthService;
 import com.evolforge.core.auth.service.dto.ClientMetadata;
+import com.evolforge.core.auth.service.dto.CurrentUserResult;
 import com.evolforge.core.auth.service.dto.EmailVerificationResult;
 import com.evolforge.core.auth.service.dto.GoogleAccountResult;
+import com.evolforge.core.auth.service.dto.MembershipDescriptor;
 import com.evolforge.core.auth.service.dto.RegistrationResult;
 import com.evolforge.core.auth.service.dto.TokenPair;
 import com.evolforge.core.igoauth.GoogleProfile;
@@ -40,6 +42,16 @@ public class AuthFacade {
         return authService.refresh(refreshToken, metadata);
     }
 
+    public void logout(String refreshToken) {
+        authService.logout(refreshToken);
+    }
+
+    public CurrentUser currentUser(String accessToken) {
+        CurrentUserResult result = authService.currentUser(accessToken);
+        UserAccount user = result.user();
+        return new CurrentUser(user.getId(), user.getEmail(), user.getDisplayName(), result.memberships());
+    }
+
     public void resendVerificationEmail(String email) {
         authService.resendVerificationEmail(email);
     }
@@ -66,5 +78,9 @@ public class AuthFacade {
     }
 
     public record RegistrationResponse(java.util.UUID userId, java.util.UUID tenantId) {
+    }
+
+    public record CurrentUser(java.util.UUID id, String email, String displayName,
+            java.util.List<MembershipDescriptor> memberships) {
     }
 }

--- a/modules/auth/src/main/java/com/evolforge/core/auth/service/dto/CurrentUserResult.java
+++ b/modules/auth/src/main/java/com/evolforge/core/auth/service/dto/CurrentUserResult.java
@@ -1,0 +1,7 @@
+package com.evolforge.core.auth.service.dto;
+
+import com.evolforge.core.auth.domain.UserAccount;
+import java.util.List;
+
+public record CurrentUserResult(UserAccount user, List<MembershipDescriptor> memberships) {
+}


### PR DESCRIPTION
## Summary
- add DTOs and JWT parsing support so AuthService can resolve the current user and revoke refresh tokens
- expose logout and current-user operations through AuthFacade and AuthController, including new REST endpoints
- extend AuthController integration tests to cover logout and /me scenarios

## Testing
- mvn test *(fails: cannot download parent POM without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68caa6a4968c83339045d36d1cfe1d27