### PR TITLE
Add tenant context resolution and membership management enhancements

### DIFF
--- a/app/src/main/java/com/evolforge/core/security/JwtPrincipal.java
+++ b/app/src/main/java/com/evolforge/core/security/JwtPrincipal.java
@@ -1,9 +1,10 @@
 package com.evolforge.core.security;
 
 import com.evolforge.core.auth.service.dto.MembershipDescriptor;
+import com.evolforge.core.tenancy.context.TenantAwarePrincipal;
 import java.util.List;
 import java.util.UUID;
 
 public record JwtPrincipal(UUID userId, String email, String displayName, List<MembershipDescriptor> memberships,
-        String tokenId) {
+        String tokenId) implements TenantAwarePrincipal {
 }

--- a/modules/tenancy/pom.xml
+++ b/modules/tenancy/pom.xml
@@ -24,5 +24,48 @@
             <artifactId>auth</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/tenancy/src/main/java/com/evolforge/core/tenancy/context/TenantAwarePrincipal.java
+++ b/modules/tenancy/src/main/java/com/evolforge/core/tenancy/context/TenantAwarePrincipal.java
@@ -1,0 +1,12 @@
+package com.evolforge.core.tenancy.context;
+
+import com.evolforge.core.auth.service.dto.MembershipDescriptor;
+import java.util.List;
+
+/**
+ * Marker interface for security principals that carry tenant memberships.
+ */
+public interface TenantAwarePrincipal {
+
+    List<MembershipDescriptor> memberships();
+}

--- a/modules/tenancy/src/main/java/com/evolforge/core/tenancy/context/TenantContext.java
+++ b/modules/tenancy/src/main/java/com/evolforge/core/tenancy/context/TenantContext.java
@@ -1,0 +1,10 @@
+package com.evolforge.core.tenancy.context;
+
+import com.evolforge.core.tenancy.domain.MembershipRole;
+import java.util.UUID;
+
+/**
+ * Context describing the current tenant and caller role.
+ */
+public record TenantContext(UUID tenantId, MembershipRole role) {
+}

--- a/modules/tenancy/src/main/java/com/evolforge/core/tenancy/context/TenantContextHolder.java
+++ b/modules/tenancy/src/main/java/com/evolforge/core/tenancy/context/TenantContextHolder.java
@@ -1,0 +1,42 @@
+package com.evolforge.core.tenancy.context;
+
+import java.util.Optional;
+import java.util.UUID;
+import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+/**
+ * Helper for storing and retrieving tenant information from the Reactor context.
+ */
+public final class TenantContextHolder {
+
+    private static final Class<TenantContext> CONTEXT_KEY = TenantContext.class;
+
+    private TenantContextHolder() {
+    }
+
+    public static Mono<TenantContext> currentContext() {
+        return Mono.deferContextual(contextView -> Mono.justOrEmpty(extractContext(contextView)));
+    }
+
+    public static Mono<UUID> currentTenantId() {
+        return currentContext().map(TenantContext::tenantId);
+    }
+
+    public static Mono<Boolean> hasRole(com.evolforge.core.tenancy.domain.MembershipRole role) {
+        return currentContext().map(ctx -> ctx.role() == role).defaultIfEmpty(false);
+    }
+
+    public static Context put(Context context, TenantContext tenantContext) {
+        return context.put(CONTEXT_KEY, tenantContext);
+    }
+
+    public static Context clear(Context context) {
+        return context.delete(CONTEXT_KEY);
+    }
+
+    private static Optional<TenantContext> extractContext(ContextView contextView) {
+        return contextView.getOrEmpty(CONTEXT_KEY).map(TenantContext.class::cast);
+    }
+}

--- a/modules/tenancy/src/main/java/com/evolforge/core/tenancy/context/TenantResolver.java
+++ b/modules/tenancy/src/main/java/com/evolforge/core/tenancy/context/TenantResolver.java
@@ -1,0 +1,89 @@
+package com.evolforge.core.tenancy.context;
+
+import com.evolforge.core.auth.service.dto.MembershipDescriptor;
+import com.evolforge.core.tenancy.domain.MembershipRole;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Resolves the tenant for the current request from either the JWT memberships or the X-Tenant-Id header.
+ */
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
+public class TenantResolver implements WebFilter {
+
+    public static final String TENANT_HEADER = "X-Tenant-Id";
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return resolveTenantContext(exchange)
+                .flatMap(tenantContext -> chain.filter(exchange)
+                        .contextWrite(ctx -> TenantContextHolder.put(ctx, tenantContext)))
+                .switchIfEmpty(chain.filter(exchange));
+    }
+
+    private Mono<TenantContext> resolveTenantContext(ServerWebExchange exchange) {
+        return exchange.getPrincipal()
+                .cast(Authentication.class)
+                .filter(Authentication::isAuthenticated)
+                .flatMap(authentication -> {
+                    Object principal = authentication.getPrincipal();
+                    if (!(principal instanceof TenantAwarePrincipal tenantAware)) {
+                        return Mono.empty();
+                    }
+                    List<MembershipDescriptor> memberships = tenantAware.memberships();
+                    if (memberships == null || memberships.isEmpty()) {
+                        return Mono.empty();
+                    }
+                    UUID requestedTenantId = extractTenantId(exchange.getRequest().getHeaders().getFirst(TENANT_HEADER));
+                    if (requestedTenantId != null) {
+                        return membershipForTenant(memberships, requestedTenantId);
+                    }
+                    if (memberships.size() == 1) {
+                        return toContext(memberships.getFirst());
+                    }
+                    return Mono.empty();
+                });
+    }
+
+    private UUID extractTenantId(String rawTenantId) {
+        if (!StringUtils.hasText(rawTenantId)) {
+            return null;
+        }
+        try {
+            return UUID.fromString(rawTenantId.trim());
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private Mono<TenantContext> membershipForTenant(List<MembershipDescriptor> memberships, UUID tenantId) {
+        return memberships.stream()
+                .filter(descriptor -> tenantId.equals(descriptor.tenantId()))
+                .findFirst()
+                .map(this::toContext)
+                .orElse(Mono.empty());
+    }
+
+    private Mono<TenantContext> toContext(MembershipDescriptor descriptor) {
+        if (descriptor == null || descriptor.tenantId() == null || !StringUtils.hasText(descriptor.role())) {
+            return Mono.empty();
+        }
+        try {
+            MembershipRole role = MembershipRole.valueOf(descriptor.role().trim().toUpperCase(Locale.ROOT));
+            return Mono.just(new TenantContext(descriptor.tenantId(), role));
+        } catch (IllegalArgumentException ex) {
+            return Mono.empty();
+        }
+    }
+}

--- a/modules/tenancy/src/main/java/com/evolforge/core/tenancy/repository/MembershipRepository.java
+++ b/modules/tenancy/src/main/java/com/evolforge/core/tenancy/repository/MembershipRepository.java
@@ -13,4 +13,6 @@ public interface MembershipRepository extends BaseRepository<Membership> {
     List<Membership> findByTenantId(UUID tenantId);
 
     Optional<Membership> findByUserIdAndTenantId(UUID userId, UUID tenantId);
+
+    long deleteByTenantIdAndUserId(UUID tenantId, UUID userId);
 }

--- a/modules/tenancy/src/main/java/com/evolforge/core/tenancy/security/TenantAccessGuard.java
+++ b/modules/tenancy/src/main/java/com/evolforge/core/tenancy/security/TenantAccessGuard.java
@@ -1,0 +1,46 @@
+package com.evolforge.core.tenancy.security;
+
+import com.evolforge.core.tenancy.context.TenantContextHolder;
+import com.evolforge.core.tenancy.domain.MembershipRole;
+import java.util.EnumSet;
+import java.util.Set;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.ReactiveAuthorizationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.authorization.AuthorizationContext;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive authorization manager that checks whether the current caller has one of the required roles
+ * within the resolved tenant context.
+ */
+public class TenantAccessGuard implements ReactiveAuthorizationManager<AuthorizationContext> {
+
+    private final Set<MembershipRole> allowedRoles;
+
+    public TenantAccessGuard(MembershipRole... allowedRoles) {
+        if (allowedRoles == null || allowedRoles.length == 0) {
+            throw new IllegalArgumentException("At least one membership role must be provided");
+        }
+        EnumSet<MembershipRole> roleSet = EnumSet.noneOf(MembershipRole.class);
+        for (MembershipRole role : allowedRoles) {
+            if (role != null) {
+                roleSet.add(role);
+            }
+        }
+        if (roleSet.isEmpty()) {
+            throw new IllegalArgumentException("At least one membership role must be provided");
+        }
+        this.allowedRoles = Set.copyOf(roleSet);
+    }
+
+    @Override
+    public Mono<AuthorizationDecision> check(Mono<Authentication> authentication, AuthorizationContext context) {
+        return authentication
+                .filter(Authentication::isAuthenticated)
+                .flatMap(auth -> TenantContextHolder.currentContext()
+                        .map(tenantContext -> new AuthorizationDecision(allowedRoles.contains(tenantContext.role())))
+                        .defaultIfEmpty(new AuthorizationDecision(false)))
+                .defaultIfEmpty(new AuthorizationDecision(false));
+    }
+}

--- a/modules/tenancy/src/test/java/com/evolforge/core/tenancy/context/TenantResolverTest.java
+++ b/modules/tenancy/src/test/java/com/evolforge/core/tenancy/context/TenantResolverTest.java
@@ -1,0 +1,109 @@
+package com.evolforge.core.tenancy.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.evolforge.core.auth.service.dto.MembershipDescriptor;
+import com.evolforge.core.tenancy.domain.MembershipRole;
+import java.security.Principal;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class TenantResolverTest {
+
+    private final TenantResolver resolver = new TenantResolver();
+
+    @Test
+    void resolvesTenantFromHeaderWhenMembershipExists() {
+        UUID tenantId = UUID.randomUUID();
+        MembershipDescriptor descriptor = new MembershipDescriptor(tenantId, MembershipRole.ADMIN.name());
+        TestPrincipal principal = new TestPrincipal("user", List.of(descriptor));
+        Authentication authentication = authenticated(principal);
+
+        AtomicReference<TenantContext> contextRef = new AtomicReference<>();
+        ServerWebExchange exchange = withRequest(MockServerHttpRequest.get("/api/test")
+                .header(TenantResolver.TENANT_HEADER, tenantId.toString())
+                .build());
+        WebFilterChain chain = serverWebExchange -> TenantContextHolder.currentContext()
+                .doOnNext(contextRef::set)
+                .then();
+
+        Mono<Void> result = resolver.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
+
+        StepVerifier.create(result).verifyComplete();
+        assertThat(contextRef.get()).isNotNull();
+        assertThat(contextRef.get().tenantId()).isEqualTo(tenantId);
+        assertThat(contextRef.get().role()).isEqualTo(MembershipRole.ADMIN);
+    }
+
+    @Test
+    void resolvesTenantWhenSingleMembershipAndNoHeader() {
+        UUID tenantId = UUID.randomUUID();
+        MembershipDescriptor descriptor = new MembershipDescriptor(tenantId, MembershipRole.AGENT.name());
+        TestPrincipal principal = new TestPrincipal("user", List.of(descriptor));
+        Authentication authentication = authenticated(principal);
+
+        AtomicReference<TenantContext> contextRef = new AtomicReference<>();
+        ServerWebExchange exchange = withRequest(MockServerHttpRequest.get("/api/test").build());
+        WebFilterChain chain = serverWebExchange -> TenantContextHolder.currentContext()
+                .doOnNext(contextRef::set)
+                .then();
+
+        Mono<Void> result = resolver.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
+
+        StepVerifier.create(result).verifyComplete();
+        assertThat(contextRef.get()).isNotNull();
+        assertThat(contextRef.get().tenantId()).isEqualTo(tenantId);
+        assertThat(contextRef.get().role()).isEqualTo(MembershipRole.AGENT);
+    }
+
+    @Test
+    void doesNotResolveWhenMembershipMissing() {
+        UUID tenantId = UUID.randomUUID();
+        MembershipDescriptor descriptor = new MembershipDescriptor(UUID.randomUUID(), MembershipRole.ADMIN.name());
+        TestPrincipal principal = new TestPrincipal("user", List.of(descriptor));
+        Authentication authentication = authenticated(principal);
+
+        AtomicReference<TenantContext> contextRef = new AtomicReference<>();
+        ServerWebExchange exchange = withRequest(MockServerHttpRequest.get("/api/test")
+                .header(TenantResolver.TENANT_HEADER, tenantId.toString())
+                .build());
+        WebFilterChain chain = serverWebExchange -> TenantContextHolder.currentContext()
+                .doOnNext(contextRef::set)
+                .then();
+
+        Mono<Void> result = resolver.filter(exchange, chain)
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
+
+        StepVerifier.create(result).verifyComplete();
+        assertThat(contextRef.get()).isNull();
+    }
+
+    private Authentication authenticated(Principal principal) {
+        return new UsernamePasswordAuthenticationToken(principal, "token",
+                AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+
+    private ServerWebExchange withRequest(ServerHttpRequest request) {
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        return exchange;
+    }
+
+    private record TestPrincipal(String name, List<MembershipDescriptor> memberships)
+            implements Principal, TenantAwarePrincipal {
+    }
+}

--- a/modules/tenancy/src/test/java/com/evolforge/core/tenancy/security/TenantAccessGuardTest.java
+++ b/modules/tenancy/src/test/java/com/evolforge/core/tenancy/security/TenantAccessGuardTest.java
@@ -1,0 +1,62 @@
+package com.evolforge.core.tenancy.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.evolforge.core.tenancy.context.TenantContext;
+import com.evolforge.core.tenancy.context.TenantContextHolder;
+import com.evolforge.core.tenancy.domain.MembershipRole;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.web.server.authorization.AuthorizationContext;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class TenantAccessGuardTest {
+
+    private final AuthorizationContext authorizationContext = null;
+
+    @Test
+    void grantsAccessWhenRoleMatches() {
+        TenantAccessGuard guard = new TenantAccessGuard(MembershipRole.ADMIN, MembershipRole.OWNER);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("user", "token");
+        authentication.setAuthenticated(true);
+
+        Mono<AuthorizationDecision> decisionMono = guard.check(Mono.just(authentication), authorizationContext)
+                .contextWrite(ctx -> TenantContextHolder.put(ctx,
+                        new TenantContext(UUID.randomUUID(), MembershipRole.ADMIN)));
+
+        StepVerifier.create(decisionMono)
+                .assertNext(decision -> assertThat(decision.isGranted()).isTrue())
+                .verifyComplete();
+    }
+
+    @Test
+    void deniesAccessWhenRoleNotAllowed() {
+        TenantAccessGuard guard = new TenantAccessGuard(MembershipRole.OWNER);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("user", "token");
+        authentication.setAuthenticated(true);
+
+        Mono<AuthorizationDecision> decisionMono = guard.check(Mono.just(authentication), authorizationContext)
+                .contextWrite(ctx -> TenantContextHolder.put(ctx,
+                        new TenantContext(UUID.randomUUID(), MembershipRole.AGENT)));
+
+        StepVerifier.create(decisionMono)
+                .assertNext(decision -> assertThat(decision.isGranted()).isFalse())
+                .verifyComplete();
+    }
+
+    @Test
+    void deniesAccessWhenContextMissing() {
+        TenantAccessGuard guard = new TenantAccessGuard(MembershipRole.AGENT);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("user", "token");
+        authentication.setAuthenticated(true);
+
+        Mono<AuthorizationDecision> decisionMono = guard.check(Mono.just(authentication), authorizationContext);
+
+        StepVerifier.create(decisionMono)
+                .assertNext(decision -> assertThat(decision.isGranted()).isFalse())
+                .verifyComplete();
+    }
+}

--- a/modules/tenancy/src/test/java/com/evolforge/core/tenancy/service/TenantServiceTest.java
+++ b/modules/tenancy/src/test/java/com/evolforge/core/tenancy/service/TenantServiceTest.java
@@ -1,0 +1,127 @@
+package com.evolforge.core.tenancy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.evolforge.core.auth.domain.UserAccount;
+import com.evolforge.core.auth.repository.UserAccountRepository;
+import com.evolforge.core.infra.config.JpaConfig;
+import com.evolforge.core.tenancy.domain.Membership;
+import com.evolforge.core.tenancy.domain.MembershipRole;
+import com.evolforge.core.tenancy.domain.Tenant;
+import com.evolforge.core.tenancy.repository.MembershipRepository;
+import com.evolforge.core.tenancy.repository.TenantRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Testcontainers(disabledWithoutDocker = true)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, TenantService.class})
+class TenantServiceTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @Autowired
+    private TenantRepository tenantRepository;
+
+    @Autowired
+    private MembershipRepository membershipRepository;
+
+    @Autowired
+    private UserAccountRepository userAccountRepository;
+
+    @Autowired
+    private TenantService tenantService;
+
+    private Tenant tenantOne;
+    private Tenant tenantTwo;
+    private UserAccount alice;
+    private UserAccount bob;
+    private UserAccount carol;
+
+    @BeforeEach
+    void setUp() {
+        tenantOne = createTenant("Tenant One");
+        tenantTwo = createTenant("Tenant Two");
+        alice = createUser("alice@example.com", "Alice");
+        bob = createUser("bob@example.com", "Bob");
+        carol = createUser("carol@example.com", "Carol");
+    }
+
+    @Test
+    void assignMembershipCreatesAndUpdates() {
+        Membership created = tenantService.assignMembership(tenantOne, alice, MembershipRole.AGENT);
+        assertThat(created.getRole()).isEqualTo(MembershipRole.AGENT);
+
+        Membership updated = tenantService.assignMembership(tenantOne, alice, MembershipRole.ADMIN);
+        assertThat(updated.getId()).isEqualTo(created.getId());
+        assertThat(updated.getRole()).isEqualTo(MembershipRole.ADMIN);
+    }
+
+    @Test
+    void updateMembershipRoleFailsWhenMissing() {
+        assertThatThrownBy(() -> tenantService.updateMembershipRole(tenantOne.getId(), UUID.randomUUID(),
+                MembershipRole.AGENT)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Membership not found");
+    }
+
+    @Test
+    void listMembersReturnsMembersForTenantOnly() {
+        tenantService.assignMembership(tenantOne, alice, MembershipRole.ADMIN);
+        tenantService.assignMembership(tenantOne, bob, MembershipRole.AGENT);
+        tenantService.assignMembership(tenantTwo, carol, MembershipRole.AGENT);
+
+        List<Membership> tenantOneMembers = tenantService.listMembers(tenantOne.getId());
+        assertThat(tenantOneMembers)
+                .hasSize(2)
+                .extracting(membership -> membership.getUser().getId())
+                .containsExactlyInAnyOrder(alice.getId(), bob.getId());
+
+        List<Membership> tenantTwoMembers = tenantService.listMembers(tenantTwo.getId());
+        assertThat(tenantTwoMembers)
+                .hasSize(1)
+                .extracting(membership -> membership.getUser().getId())
+                .containsExactly(carol.getId());
+    }
+
+    @Test
+    void removeMembershipIsolatedPerTenant() {
+        tenantService.assignMembership(tenantOne, alice, MembershipRole.ADMIN);
+        tenantService.assignMembership(tenantTwo, alice, MembershipRole.AGENT);
+
+        boolean removed = tenantService.removeMembership(tenantOne.getId(), alice.getId());
+        assertThat(removed).isTrue();
+        assertThat(membershipRepository.findByUserIdAndTenantId(alice.getId(), tenantOne.getId())).isEmpty();
+        assertThat(membershipRepository.findByUserIdAndTenantId(alice.getId(), tenantTwo.getId())).isPresent();
+    }
+
+    private Tenant createTenant(String name) {
+        Tenant tenant = new Tenant();
+        tenant.setName(name);
+        return tenantRepository.saveAndFlush(tenant);
+    }
+
+    private UserAccount createUser(String email, String displayName) {
+        UserAccount user = new UserAccount();
+        user.setEmail(email);
+        user.setDisplayName(displayName);
+        user.setEmailVerified(true);
+        user.setDisabled(false);
+        return userAccountRepository.saveAndFlush(user);
+    }
+}

--- a/modules/tenancy/src/test/resources/application-test.yml
+++ b/modules/tenancy/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  main:
+    allow-bean-definition-overriding: true
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+  flyway:
+    enabled: true
+logging:
+  level:
+    root: WARN
+app:
+  auth:
+    jwt:
+      secret: test-secret-value-change-me-1234567890-test-secret-value-change-me
+      issuer: test-issuer


### PR DESCRIPTION
## Summary
- add tenant context holder and resolver to capture tenant membership from JWT or X-Tenant-Id and expose a reactive access guard
- extend membership repositories and services to support role assignment, updates, listing, and removal operations with tenant isolation tests
- expose tenant memberships via JwtPrincipal and configure tenancy module dependencies and test fixtures

## Testing
- mvn -pl modules/tenancy,app test *(fails: unable to download Spring Boot parent POM because the build environment has no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cad73c261c833397e63bc89a5fa63c