### PR TITLE
Add Swagger documentation for authentication API

### DIFF
--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -1,0 +1,22 @@
+# Swagger / OpenAPI Documentation
+
+## URL
+- Swagger UI: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
+- OpenAPI JSON: [http://localhost:8080/v3/api-docs](http://localhost:8080/v3/api-docs)
+
+> **Tip:** When the service is deployed behind a reverse proxy, ensure the proxy forwards the `X-Forwarded-*` headers so that Swagger UI can build correct absolute URLs.
+
+## Authentication via Swagger UI
+1. Obtain an access token using `/api/auth/login`, `/api/auth/token/refresh`, or `/api/auth/google/callback`.
+2. Click the **Authorize** button in the top-right corner of Swagger UI.
+3. Enter the token as `Bearer <access_token>` and click **Authorize**.
+4. All endpoints that require authentication (e.g. `GET /api/auth/me`) will now include the bearer token automatically when executed from Swagger UI.
+
+## Implementation Best Practices
+- **Keep documentation close to code**: Use `@Operation`, `@ApiResponse`, and `@Schema` annotations on controllers and DTOs so that the contract evolves with the implementation.
+- **Document security schemes once**: Define bearer token authentication in a central configuration (`OpenApiConfig`) and reference it with `@SecurityRequirement` on protected endpoints.
+- **Describe request/response models**: Annotate request records with `@Schema` to highlight constraints, examples, and field descriptions.
+- **Expose only necessary endpoints**: Permit Swagger and OpenAPI paths explicitly in the security configuration to avoid exposing other internal routes unintentionally.
+- **Version your API**: Update the OpenAPI `Info` metadata (`title`, `version`, `description`) whenever introducing breaking changes.
+- **Keep dependencies updated**: Regularly review `springdoc-openapi` for updates to stay compatible with new Spring Boot releases and security patches.
+

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/evolforge/core/auth/web/AuthController.java
+++ b/src/main/java/com/evolforge/core/auth/web/AuthController.java
@@ -8,6 +8,14 @@ import com.evolforge.core.auth.service.dto.ClientMetadata;
 import com.evolforge.core.auth.service.dto.TokenPair;
 import com.evolforge.core.igoauth.GoogleOAuthResult;
 import com.evolforge.core.igoauth.GoogleOAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -20,6 +28,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,13 +37,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ServerWebExchange;
-import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 @RestController
 @RequestMapping(path = "/api/auth", produces = MediaType.APPLICATION_JSON_VALUE)
 @Validated
+@Tag(name = "Authentication", description = "Authentication, registration, and identity endpoints")
 public class AuthController {
 
     private final AuthFacade authFacade;
@@ -46,6 +55,13 @@ public class AuthController {
     }
 
     @PostMapping(path = "/register", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Register a new account",
+            description = "Creates a new user account and sends an email verification link.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "User registered successfully"),
+        @ApiResponse(responseCode = "400", description = "Validation failed", content = @Content)
+    })
     public Mono<ResponseEntity<RegistrationResponse>> register(@Valid @RequestBody RegisterRequest request) {
         return Mono.fromCallable(() -> authFacade.register(request.email(), request.password(), request.displayName()))
                 .map(response -> ResponseEntity.status(HttpStatus.CREATED).body(response))
@@ -53,6 +69,13 @@ public class AuthController {
     }
 
     @PostMapping(path = "/login", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Authenticate with email and password",
+            description = "Authenticates the user and returns a JWT access and refresh token pair.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Authentication succeeded"),
+        @ApiResponse(responseCode = "401", description = "Invalid credentials", content = @Content)
+    })
     public Mono<TokenResponse> login(@Valid @RequestBody LoginRequest request, ServerWebExchange exchange) {
         return Mono.fromCallable(() -> authFacade.login(request.email(), request.password(),
                         extractMetadata(exchange)))
@@ -61,6 +84,13 @@ public class AuthController {
     }
 
     @PostMapping(path = "/token/refresh", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Refresh an access token",
+            description = "Exchanges a valid refresh token for a new access token and refresh token pair.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "New tokens issued"),
+        @ApiResponse(responseCode = "401", description = "Refresh token is invalid", content = @Content)
+    })
     public Mono<TokenResponse> refresh(@Valid @RequestBody RefreshRequest request, ServerWebExchange exchange) {
         return Mono.fromCallable(() -> authFacade.refresh(request.refreshToken(), extractMetadata(exchange)))
                 .map(AuthController::toTokenResponse)
@@ -68,6 +98,13 @@ public class AuthController {
     }
 
     @PostMapping(path = "/logout", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Invalidate a refresh token",
+            description = "Revokes the provided refresh token so it can no longer be used.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Refresh token revoked"),
+        @ApiResponse(responseCode = "400", description = "Refresh token is missing or invalid", content = @Content)
+    })
     public Mono<ResponseEntity<Void>> logout(@Valid @RequestBody LogoutRequest request) {
         return Mono.fromRunnable(() -> authFacade.logout(request.refreshToken()))
                 .then(Mono.fromSupplier(AuthController::noContentResponse))
@@ -75,6 +112,13 @@ public class AuthController {
     }
 
     @PostMapping(path = "/verify-email/resend", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Resend an email verification link",
+            description = "Sends a new email verification link to the provided email address.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Verification email sent"),
+        @ApiResponse(responseCode = "404", description = "Account not found", content = @Content)
+    })
     public Mono<ResponseEntity<Void>> resendVerification(@Valid @RequestBody ResendVerificationRequest request) {
         return Mono.fromRunnable(() -> authFacade.resendVerificationEmail(request.email()))
                 .then(Mono.fromSupplier(AuthController::noContentResponse))
@@ -82,6 +126,13 @@ public class AuthController {
     }
 
     @GetMapping(path = "/verify-email")
+    @Operation(
+            summary = "Verify email address",
+            description = "Validates a verification token that was sent via email.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Email verification result returned"),
+        @ApiResponse(responseCode = "400", description = "Verification token is invalid", content = @Content)
+    })
     public Mono<EmailVerificationResponse> verifyEmail(@RequestParam("token") String token) {
         return Mono.fromCallable(() -> authFacade.verifyEmail(token))
                 .map(result -> new EmailVerificationResponse(result.verified()))
@@ -89,6 +140,13 @@ public class AuthController {
     }
 
     @PostMapping(path = "/password/forgot", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Start password reset flow",
+            description = "Generates a password reset email for the specified account.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Reset email sent"),
+        @ApiResponse(responseCode = "404", description = "Account not found", content = @Content)
+    })
     public Mono<ResponseEntity<Void>> forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
         return Mono.fromRunnable(() -> authFacade.requestPasswordReset(request.email()))
                 .then(Mono.fromSupplier(AuthController::noContentResponse))
@@ -96,6 +154,13 @@ public class AuthController {
     }
 
     @PostMapping(path = "/password/reset", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Reset password",
+            description = "Updates the account password using a valid reset token.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Password updated"),
+        @ApiResponse(responseCode = "400", description = "Reset token is invalid", content = @Content)
+    })
     public Mono<ResponseEntity<Void>> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
         return Mono.fromRunnable(() -> authFacade.resetPassword(request.token(), request.newPassword()))
                 .then(Mono.fromSupplier(AuthController::noContentResponse))
@@ -103,15 +168,31 @@ public class AuthController {
     }
 
     @GetMapping(path = "/google/authorize")
-    public Mono<ResponseEntity<Void>> googleAuthorize(@RequestParam(value = "state", required = false) String state) {
+    @Operation(
+            summary = "Build Google OAuth authorization URL",
+            description = "Returns an HTTP redirect to Google's OAuth authorization endpoint.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "302", description = "Redirect to Google OAuth"),
+        @ApiResponse(responseCode = "500", description = "Failed to build the authorization URL", content = @Content)
+    })
+    public Mono<ResponseEntity<Void>> googleAuthorize(@Parameter(description = "Opaque state parameter to be returned by Google", required = false)
+            @RequestParam(value = "state", required = false) String state) {
         return Mono.fromCallable(() -> googleOAuthService.buildAuthorizationUrl(state))
                 .map(url -> ResponseEntity.status(HttpStatus.FOUND).location(URI.create(url)).<Void>build())
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
     @GetMapping(path = "/google/callback")
+    @Operation(
+            summary = "Handle Google OAuth callback",
+            description = "Exchanges an authorization code issued by Google for a token pair and logs the user in.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Login succeeded"),
+        @ApiResponse(responseCode = "400", description = "Invalid authorization code", content = @Content)
+    })
     public Mono<TokenResponse> googleCallback(
-            @RequestParam("code") String code,
+            @Parameter(description = "Authorization code issued by Google") @RequestParam("code") String code,
+            @Parameter(description = "Opaque state returned by Google", required = false)
             @RequestParam(value = "state", required = false) String state,
             ServerWebExchange exchange) {
         return Mono.fromCallable(() -> googleOAuthService.exchangeCode(code))
@@ -122,6 +203,14 @@ public class AuthController {
     }
 
     @GetMapping(path = "/me")
+    @Operation(
+            summary = "Fetch the current authenticated user",
+            description = "Returns profile information and tenant memberships for the authenticated user.",
+            security = {@SecurityRequirement(name = "BearerAuth")})
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "User details returned"),
+        @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token", content = @Content)
+    })
     public Mono<CurrentUserResponse> currentUser(ServerWebExchange exchange) {
         return Mono.fromCallable(() -> authFacade.currentUser(extractAccessToken(exchange)))
                 .map(AuthController::toCurrentUserResponse)
@@ -166,43 +255,55 @@ public class AuthController {
     }
 
     public record RegisterRequest(
-            @Email @NotBlank String email,
-            @NotBlank @Size(min = 8, max = 72) String password,
-            @NotBlank @Size(max = 100) String displayName) {
+            @Email @NotBlank @Schema(description = "User email address", example = "user@example.com") String email,
+            @NotBlank @Size(min = 8, max = 72) @Schema(description = "Password (8-72 characters)") String password,
+            @NotBlank @Size(max = 100) @Schema(description = "Display name shown to other users") String displayName) {
     }
 
-    public record LoginRequest(@Email @NotBlank String email, @NotBlank String password) {
+    public record LoginRequest(
+            @Email @NotBlank @Schema(description = "User email address", example = "user@example.com") String email,
+            @NotBlank @Schema(description = "Password") String password) {
     }
 
-    public record RefreshRequest(@NotBlank String refreshToken) {
+    public record RefreshRequest(@NotBlank @Schema(description = "Refresh token issued during login") String refreshToken) {
     }
 
-    public record LogoutRequest(@NotBlank String refreshToken) {
+    public record LogoutRequest(@NotBlank @Schema(description = "Refresh token to revoke") String refreshToken) {
     }
 
-    public record ResendVerificationRequest(@Email @NotBlank String email) {
+    public record ResendVerificationRequest(
+            @Email @NotBlank @Schema(description = "Email that should receive the verification link") String email) {
     }
 
-    public record EmailVerificationResponse(boolean verified) {
+    public record EmailVerificationResponse(
+            @Schema(description = "Whether the email was successfully verified") boolean verified) {
     }
 
-    public record ForgotPasswordRequest(@Email @NotBlank String email) {
+    public record ForgotPasswordRequest(
+            @Email @NotBlank @Schema(description = "Email that should receive the reset instructions") String email) {
     }
 
-    public record ResetPasswordRequest(@NotBlank String token, @NotBlank @Size(min = 8, max = 72) String newPassword) {
+    public record ResetPasswordRequest(
+            @NotBlank @Schema(description = "Password reset token sent via email") String token,
+            @NotBlank @Size(min = 8, max = 72) @Schema(description = "New password (8-72 characters)") String newPassword) {
     }
 
-    public record TokenResponse(String accessToken, String refreshToken, long expiresIn) {
+    public record TokenResponse(
+            @Schema(description = "JWT access token to be used in the Authorization header") String accessToken,
+            @Schema(description = "Refresh token used to renew access") String refreshToken,
+            @Schema(description = "Seconds until the access token expires") long expiresIn) {
     }
 
     public record CurrentUserResponse(
-            java.util.UUID id,
-            String email,
-            String displayName,
-            java.util.List<MembershipResponse> memberships) {
+            @Schema(description = "Unique user identifier") java.util.UUID id,
+            @Schema(description = "User email address") String email,
+            @Schema(description = "Display name of the user") String displayName,
+            @Schema(description = "Tenant memberships the user belongs to") java.util.List<MembershipResponse> memberships) {
     }
 
-    public record MembershipResponse(java.util.UUID tenantId, String role) {
+    public record MembershipResponse(
+            @Schema(description = "Tenant identifier") java.util.UUID tenantId,
+            @Schema(description = "Role granted within the tenant") String role) {
     }
 
     private static CurrentUserResponse toCurrentUserResponse(CurrentUser currentUser) {

--- a/src/main/java/com/evolforge/core/infra/config/OpenApiConfig.java
+++ b/src/main/java/com/evolforge/core/infra/config/OpenApiConfig.java
@@ -1,0 +1,35 @@
+package com.evolforge.core.infra.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI rielHomeOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("RielHome API")
+                        .version("v1")
+                        .description("API documentation for the RielHome platform.")
+                        .contact(new Contact().name("RielHome Team").email("support@rielhome.com"))
+                        .license(new License().name("Proprietary")))
+                .servers(List.of(new Server().url("/").description("Default server")))
+                .components(new Components().addSecuritySchemes(
+                        "BearerAuth",
+                        new SecurityScheme()
+                                .name("Authorization")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/src/main/java/com/evolforge/core/security/SecurityConfig.java
+++ b/src/main/java/com/evolforge/core/security/SecurityConfig.java
@@ -25,7 +25,10 @@ public class SecurityConfig {
             "/api/auth/**",
             "/",
             "/index.html",
-            "/favicon.ico"
+            "/favicon.ico",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
     };
 
     private static final String[] PUBLIC_STATIC_RESOURCES = {


### PR DESCRIPTION
## Summary
- add SpringDoc OpenAPI dependency and configuration with JWT bearer scheme
- document every authentication endpoint with Swagger annotations and schema metadata
- expose Swagger UI publicly and add usage notes in docs/swagger.md

## Testing
- `./mvnw -q test` *(fails: Maven wrapper could not download due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ef7c9c948333a442d7c00981c384