### PR TITLE
Fix Argon2 encoder missing class by adding BouncyCastle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
             <artifactId>spring-security-crypto</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.78.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jpa</artifactId>
         </dependency>


### PR DESCRIPTION
## Summary
- add the BouncyCastle provider dependency so Argon2 password encoding can initialize

## Testing
- ./mvnw -DskipTests package *(fails: network is unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68e16eabfc7483338e72e8ae43bfd8ed